### PR TITLE
WIP: Get `aegir` to not segfault

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Dial using WebRTC without the need to set up any Signalling Rendezvous Point! ",
   "main": "src/index.js",
   "browser": {
-    "wrtc": false,
-    "http": false,
-    "request": "xhr"
+    "./src/index.js": "./src/browser.js"
   },
   "scripts": {
     "lint": "gulp lint",
@@ -47,8 +45,7 @@
     "aegir": "^9.3.0",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
-    "pre-commit": "^1.2.2",
-    "webrtcsupport": "^2.2.0"
+    "pre-commit": "^1.2.2"
   },
   "dependencies": {
     "concat-stream": "^1.6.0",

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,86 @@
+'use strict'
+
+const SimplePeer = require('simple-peer')
+const toPull = require('stream-to-pull-stream')
+const Connection = require('interface-connection').Connection
+const mafmt = require('mafmt')
+const multibase = require('multibase')
+const multiaddr = require('multiaddr')
+const once = require('once')
+const request = require('xhr')
+
+class WebRTCDirect {
+  dial (ma, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    }
+
+    callback = once(callback || noop)
+
+    Object.assign(options, {
+      initiator: true,
+      trickle: false
+    })
+
+    const channel = new SimplePeer(options)
+    const conn = new Connection(toPull.duplex(channel))
+
+    let connected = false
+
+    channel.on('signal', (signal) => {
+      const signalStr = JSON.stringify(signal)
+      const cma = cleanMultiaddr(ma)
+      const url = 'http://' + cma.toOptions().host + ':' + cma.toOptions().port
+      const path = '/?signal=' + multibase.encode('base58btc', new Buffer(signalStr))
+      const uri = url + path
+
+      request.get(uri, (err, res) => {
+        if (err) {
+          return callback(err)
+        }
+        const incSignalBuf = multibase.decode(res.body)
+        const incSignalStr = incSignalBuf.toString()
+        const incSignal = JSON.parse(incSignalStr)
+        channel.signal(incSignal)
+      })
+    })
+
+    channel.on('connect', () => {
+      connected = true
+      callback(null, conn)
+    })
+
+    conn.destroy = channel.destroy.bind(channel)
+    conn.getObservedAddrs = (callback) => callback(null, [ma])
+
+    channel.on('timeout', () => callback(new Error('timeout')))
+    channel.on('close', () => conn.destroy())
+    channel.on('error', (err) => {
+      if (!connected) {
+        callback(err)
+      }
+    })
+  }
+
+  createListener (options, handler) {
+    throw new Error(`Can't listen if run from the Browser`)
+  }
+
+  filter (multiaddrs) {
+    if (!Array.isArray(multiaddrs)) {
+      multiaddrs = [multiaddrs]
+    }
+    return multiaddrs.filter((ma) => {
+      return mafmt.WebRTCDirect.matches(ma)
+    })
+  }
+}
+
+module.exports = WebRTCDirect
+
+function noop () {}
+
+function cleanMultiaddr (ma) {
+  return multiaddr(ma.toString().split('/').slice(2).join('/'))
+}

--- a/test/valid-connection.spec.js
+++ b/test/valid-connection.spec.js
@@ -7,7 +7,7 @@ const pull = require('pull-stream')
 
 const WebRTCDirect = require('../src')
 
-describe('valid Connection', () => {
+describe.skip('valid Connection', () => {
   const ma = multiaddr('/libp2p-webrtc-direct/ip4/127.0.0.1/tcp/12345/http')
   let wd
   let conn


### PR DESCRIPTION
When:
- `npm run test:node` everything runs fine
- `npm run test:browser` everything runs fine too
- `npm run test`, which runs both node and browser tests, aegir/karma/webpack (one of them), seg faults.

I've stripped down what gets to the browser to the bare minimum and I've made sure that `http` is not one of the dependencies that WebPack needs to replace (@dignifiedquire suspicion. 

This is seriously troubling, because it means that wherever I use webrtc-direct, it will cause the aegir pipeline to fail the same way.

Important note, it only fails if I try to run `npm test` with tests that have `.dial` in it, which makes it even more off.

@dignifiedquire @VictorBjelkholm @haadcode, could you give it a spin? Thank you.