### PR TITLE
fix: options no longer ignored in createListener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,9 +100,9 @@ class WebRTCDirect {
       const incSignalBuf = multibase.decode(Buffer.from(incSignalStr))
       const incSignal = JSON.parse(incSignalBuf.toString())
 
-      const options = {
+      Object.assign(options, {
         trickle: false
-      }
+      })
 
       if (isNode) {
         options.wrtc = wrtc


### PR DESCRIPTION
The options passed to createListener are now passed through to SimplePeer as done in the dial function.

closes #20 