### PR TITLE
test: avoid stun in unit tests for more predicable test durations

### DIFF
--- a/test/dial.spec.js
+++ b/test/dial.spec.js
@@ -21,7 +21,7 @@ describe('dial', () => {
   })
 
   it('dial on IPv4, check callback', (done) => {
-    wd.dial(ma, (err, conn) => {
+    wd.dial(ma, { config: {} }, (err, conn) => {
       expect(err).to.not.exist()
 
       const data = Buffer.from('some data')
@@ -41,7 +41,7 @@ describe('dial', () => {
   it('dial offline / non-existent node on IPv4, check callback', (done) => {
     let maOffline = multiaddr('/ip4/127.0.0.1/tcp/55555/http/p2p-webrtc-direct')
 
-    wd.dial(maOffline, (err, conn) => {
+    wd.dial(maOffline, { config: {} }, (err, conn) => {
       expect(err).to.exist()
       done()
     })

--- a/test/listen.js
+++ b/test/listen.js
@@ -19,7 +19,7 @@ describe('listen', () => {
   })
 
   it('listen, check for callback', (done) => {
-    const listener = wd.createListener((conn) => {})
+    const listener = wd.createListener({ config: {} }, (conn) => {})
 
     listener.listen(ma, (err) => {
       expect(err).to.not.exist()
@@ -28,7 +28,7 @@ describe('listen', () => {
   })
 
   it('listen, check for listening event', (done) => {
-    const listener = wd.createListener((conn) => {})
+    const listener = wd.createListener({ config: {} }, (conn) => {})
 
     listener.once('listening', () => {
       listener.close(done)
@@ -37,7 +37,7 @@ describe('listen', () => {
   })
 
   it('listen, check for the close event', (done) => {
-    const listener = wd.createListener((conn) => {})
+    const listener = wd.createListener({ config: {} }, (conn) => {})
     listener.listen(ma, (err) => {
       expect(err).to.not.exist()
       listener.once('close', done)
@@ -62,7 +62,7 @@ describe('listen', () => {
   })
 
   it('getAddrs', (done) => {
-    const listener = wd.createListener((conn) => {})
+    const listener = wd.createListener({ config: {} }, (conn) => {})
     listener.listen(ma, (err) => {
       expect(err).to.not.exist()
       listener.getAddrs((err, addrs) => {

--- a/test/valid-connection.spec.js
+++ b/test/valid-connection.spec.js
@@ -19,7 +19,7 @@ describe('valid Connection', () => {
   before((done) => {
     wd = new WebRTCDirect()
 
-    wd.dial(ma, (err, _conn) => {
+    wd.dial(ma, { config: {} }, (err, _conn) => {
       expect(err).to.not.exist()
       conn = _conn
       done()


### PR DESCRIPTION
As mentioned in #23:
> I also tried disabling the STUN servers in the test cases. This makes them all green on my machine. This seems like a good way to make them more reliable. The Server-Reflexive candidates won't be usable anyway since both peers are on the local machine, behind the same NAT.

~Note: Depends on #23 for the options to be passed to simple-peer.~