### PR TITLE
Generate Typescript Typings via JsDoc

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,12 @@
+{
+    "recurseDepth": 10,
+    "source": {
+        "include": ["src/"],
+        "exclude": ["node_modules"]
+    },
+    "opts": {
+        "destination": "src/",
+        "template": "./node_modules/tsd-jsdoc/dist",
+        "recurse": true
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Dial using WebRTC without the need to set up any Signalling Rendezvous Point! ",
   "leadMaintainer": "Vasco Santos <vasco.santos@moxy.studio>",
   "main": "src/index.js",
+  "typings": "src/types.d.ts",
   "browser": {
     "wrtc": false,
     "http": false,
@@ -19,7 +20,8 @@
     "release-minor": "aegir release --type minor --target node --target browser",
     "release-major": "aegir release --type major --target node --target browser",
     "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider coveralls"
+    "coverage-publish": "aegir coverage --provider coveralls",
+    "generate-typings": "./node_modules/.bin/jsdoc -c ./.jsdoc.json"
   },
   "pre-push": [
     "lint",
@@ -48,7 +50,10 @@
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "gulp": "^4.0.0",
+    "jsdoc": "^3.6.3",
     "multiaddr": "^6.0.6",
+    "tsd-jsdoc": "^2.3.1",
+    "typescript-definition-tester": "0.0.6",
     "webrtcsupport": "^2.2.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 'use strict'
+/**
+ * @module js-libp2p-webrtc-direct
+ */
 
 const wrtc = require('wrtc')
 const SimplePeer = require('simple-peer')
@@ -19,7 +22,16 @@ function cleanMultiaddr (ma) {
   return ma.decapsulate('/p2p-webrtc-direct')
 }
 
+/**
+ * @class
+ */
 class WebRTCDirect {
+  /**
+   *
+   * @param {*} ma
+   * @param {object} options
+   * @param {function} callback
+   */
   dial (ma, options, callback) {
     if (typeof options === 'function') {
       callback = options
@@ -76,7 +88,11 @@ class WebRTCDirect {
       }
     })
   }
-
+  /**
+   *
+   * @param {object} options
+   * @param {function} handler 
+   */
   createListener (options, handler) {
     if (!isNode) {
       throw new Error(`Can't listen if run from the Browser`)
@@ -161,7 +177,10 @@ class WebRTCDirect {
 
     return listener
   }
-
+  /**
+   *
+   * @param {*} multiaddrs 
+   */
   filter (multiaddrs) {
     if (!Array.isArray(multiaddrs)) {
       multiaddrs = [multiaddrs]

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,29 @@
+/**
+ * @module js-libp2p-webrtc-direct
+ */
+declare module "js-libp2p-webrtc-direct" {
+    /**
+     * @class
+     */
+    class WebRTCDirect {
+        /**
+         *
+         * @param {*} ma
+         * @param {object} options
+         * @param {function} callback
+         */
+        dial(ma: any, options: any, callback: (...params: any[]) => any): void;
+        /**
+         *
+         * @param {object} options
+         * @param {function} handler
+         */
+        createListener(options: any, handler: (...params: any[]) => any): void;
+        /**
+         *
+         * @param {*} multiaddrs
+         */
+        filter(multiaddrs: any): void;
+    }
+}
+


### PR DESCRIPTION
Generates Typescript Typings via JsDoc

* Adds typings to thejs-libp2p-tcp module
* Add typings generation to travis.yml
* Include typings test