### PR TITLE
chore: use libp2p-interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,17 +45,21 @@
   "devDependencies": {
     "aegir": "^20.3.1",
     "chai": "^4.2.0",
+    "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
+    "it-pipe": "^1.1.0",
     "multiaddr": "^7.1.0",
+    "streaming-iterables": "^4.1.2",
     "webrtcsupport": "^2.2.0"
   },
   "dependencies": {
     "abortable-iterator": "^2.1.0",
     "class-is": "^1.1.0",
     "concat-stream": "^2.0.0",
+    "debug": "^4.1.1",
     "detect-node": "^2.0.4",
     "err-code": "^2.0.0",
-    "interface-transport": "libp2p/interface-transport#chore/skip-abort-while-reading-for-webrtc",
+    "libp2p-interfaces": "libp2p/js-interfaces#skip-abort-while-reading",
     "libp2p-utils": "^0.1.0",
     "mafmt": "^7.0.0",
     "multibase": "~0.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const assert = require('debug')
 const debug = require('debug')
 const log = debug('libp2p:webrtcdirect')
 log.error = debug('libp2p:webrtcdirect:error')
@@ -31,7 +30,9 @@ class WebRTCDirect {
    * @param {Upgrader} options.upgrader
    */
   constructor ({ upgrader }) {
-    assert(upgrader, 'An upgrader must be provided. See https://github.com/libp2p/interface-transport#upgrader.')
+    if (!upgrader) {
+      throw new Error('An upgrader must be provided. See https://github.com/libp2p/interface-transport#upgrader.')
+    }
     this._upgrader = upgrader
   }
 

--- a/test/compliance.js
+++ b/test/compliance.js
@@ -3,13 +3,13 @@
 
 const wrtc = require('wrtc')
 
-const tests = require('interface-transport')
+const testsTransport = require('libp2p-interfaces/src/transport/tests')
 const multiaddr = require('multiaddr')
 
 const WDirect = require('../src')
 
 describe('interface-transport compliance', () => {
-  tests({
+  testsTransport({
     setup ({ upgrader }) {
       const ws = new WDirect({ upgrader, wrtc: wrtc })
 

--- a/test/listen.js
+++ b/test/listen.js
@@ -7,6 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
+const delay = require('delay')
 const multiaddr = require('multiaddr')
 const pipe = require('it-pipe')
 
@@ -87,14 +88,15 @@ describe('listen', () => {
     expect(listener1.__connections).to.have.lengthOf(0)
 
     const conn = await wd.dial(ma1)
+    // wait for listener to know of the connect
+    await delay(1000)
+
     expect(listener1.__connections).to.have.lengthOf(1)
 
     await conn.close()
 
     // wait for listener to know of the disconnect
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1000)
-    })
+    await delay(1000)
 
     expect(listener1.__connections).to.have.lengthOf(0)
   })


### PR DESCRIPTION
This PR changes the `interface-transport` into `libp2p-interfaces` module.

Other than that, this PR adds missing dependencies and removes the `assert` module as a result of:

> The polyfill is big, we can simulate it by throwing an Error and it doesn't work under React Native.
