### PR TITLE
chore: update breaking deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
   - '12'
+  - '14'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -42,8 +42,12 @@
     "url": "https://github.com/libp2p/js-libp2p-webrtc-direct/issues"
   },
   "homepage": "https://github.com/libp2p/js-libp2p-webrtc-direct#readme",
+  "engines": {
+    "node": ">=12.0.0",
+    "npm": ">=6.0.0"
+  },
   "devDependencies": {
-    "aegir": "^20.3.1",
+    "aegir": "^29.2.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "it-pipe": "^1.1.0",
@@ -55,18 +59,19 @@
     "abortable-iterator": "^3.0.0",
     "class-is": "^1.1.0",
     "concat-stream": "^2.0.0",
-    "debug": "^4.1.1",
+    "debug": "^4.3.1",
     "detect-node": "^2.0.4",
     "err-code": "^2.0.0",
     "libp2p-interfaces": "libp2p/js-interfaces#chore/skip-abort-while-reading-for-webrtc",
     "libp2p-utils": "^0.2.3",
+    "libp2p-webrtc-peer": "^10.0.1",
     "mafmt": "^8.0.1",
-    "multibase": "~0.6.0",
+    "multibase": "^3.1.0",
     "once": "^1.4.0",
     "request": "^2.88.0",
-    "simple-peer": "9.6.0",
-    "stream-to-it": "^0.1.1",
-    "wrtc": "~0.4.2",
+    "stream-to-it": "^0.2.2",
+    "uint8arrays": "^1.1.0",
+    "wrtc": "~0.4.6",
     "xhr": "^2.5.0"
   },
   "contributors": [

--- a/src/listener.js
+++ b/src/listener.js
@@ -8,8 +8,9 @@ log.error = debug('libp2p:webrtcdirect:listener:error')
 
 const isNode = require('detect-node')
 const wrtc = require('wrtc')
-const SimplePeer = require('simple-peer')
+const SimplePeer = require('libp2p-webrtc-peer')
 const multibase = require('multibase')
+const toString = require('uint8arrays/to-string')
 
 const toConnection = require('./socket-to-conn')
 
@@ -28,8 +29,8 @@ module.exports = ({ handler, upgrader }, options = {}) => {
 
     const path = req.url
     const incSignalStr = path.split('?signal=')[1]
-    const incSignalBuf = multibase.decode(Buffer.from(incSignalStr))
-    const incSignal = JSON.parse(incSignalBuf.toString())
+    const incSignalBuf = multibase.decode(incSignalStr)
+    const incSignal = JSON.parse(toString(incSignalBuf))
 
     options = {
       trickle: false,
@@ -50,8 +51,8 @@ module.exports = ({ handler, upgrader }, options = {}) => {
     })
     channel.on('signal', (signal) => {
       const signalStr = JSON.stringify(signal)
-      const signalEncoded = multibase.encode('base58btc', Buffer.from(signalStr))
-      res.end(signalEncoded.toString())
+      const signalEncoded = multibase.encode('base58btc', new TextEncoder().encode(signalStr))
+      res.end(toString(signalEncoded))
     })
 
     channel.signal(incSignal)

--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -26,7 +26,7 @@ module.exports = (socket, options = {}) => {
         await sink((async function * () {
           for await (const chunk of source) {
             // Convert BufferList to Buffer
-            yield Buffer.isBuffer(chunk) ? chunk : chunk.slice()
+            yield chunk instanceof Uint8Array ? chunk : chunk.slice()
           }
         })())
       } catch (err) {

--- a/test/dial.spec.js
+++ b/test/dial.spec.js
@@ -11,6 +11,7 @@ const multiaddr = require('multiaddr')
 
 const pipe = require('it-pipe')
 const { collect } = require('streaming-iterables')
+const fromString = require('uint8arrays/from-string')
 
 const WebRTCDirect = require('../src')
 
@@ -31,7 +32,7 @@ describe('dial', function () {
 
   it('dial on IPv4', async () => {
     const conn = await wd.dial(ma)
-    const data = Buffer.from('some data')
+    const data = fromString('some data')
 
     const values = await pipe(
       [data],


### PR DESCRIPTION
This PR updates deps:

- use uint8array
- use `libp2p-webrtc-peer` for the time being as it is already migrated to uint8array

Node support was bumped to 12 and next