### PR TITLE
fix: add remote addr on listener connection

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -11,6 +11,7 @@ const wrtc = require('wrtc')
 const SimplePeer = require('libp2p-webrtc-peer')
 const multibase = require('multibase')
 const toString = require('uint8arrays/to-string')
+const toMultiaddr = require('libp2p-utils/src/ip-port-to-multiaddr')
 
 const toConnection = require('./socket-to-conn')
 
@@ -40,7 +41,9 @@ module.exports = ({ handler, upgrader }, options = {}) => {
 
     const channel = new SimplePeer(options)
 
-    const maConn = toConnection(channel, listener.__connections)
+    const maConn = toConnection(channel, {
+      remoteAddr: toMultiaddr(req.connection.remoteAddress, req.connection.remotePort)
+    })
     log('new inbound connection %s', maConn.remoteAddr)
 
     channel.on('error', (err) => {

--- a/src/socket-to-conn.js
+++ b/src/socket-to-conn.js
@@ -48,8 +48,7 @@ module.exports = (socket, options = {}) => {
       ? toMultiaddr(socket.localAddress, socket.localPort) : undefined,
 
     // If the remote address was passed, use it - it may have the peer ID encapsulated
-    remoteAddr: options.remoteAddr || (socket.remoteAddress && socket.remotePort
-      ? toMultiaddr(socket.remoteAddress, socket.remotePort) : undefined),
+    remoteAddr: options.remoteAddr,
 
     timeline: { open: Date.now() },
 

--- a/test/listen.js
+++ b/test/listen.js
@@ -97,5 +97,31 @@ describe('listen', () => {
     })
 
     expect(listener1.__connections).to.have.lengthOf(0)
+
+    await listener1.close()
+  })
+
+  it('should have remoteAddress in listener connection', async function () {
+    this.timeout(20e3)
+
+    const ma1 = multiaddr('/ip4/127.0.0.1/tcp/12346/http/p2p-webrtc-direct')
+
+    const wd1 = new WebRTCDirect({ upgrader: mockUpgrader })
+    const listener1 = wd1.createListener((conn) => {
+      expect(conn.remoteAddr).to.exist()
+      pipe(conn, conn)
+    })
+
+    await listener1.listen(ma1)
+    const conn = await wd.dial(ma1)
+    expect(conn.remoteAddr).to.exist()
+
+    await conn.close()
+
+    // wait for listener to know of the disconnect
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+    await listener1.close()
   })
 })


### PR DESCRIPTION
This PR fixes `webrtc-direct` transport adding the remoteAddress when creating a listening connection. Now, both the dialer and the listener provide the remoteAddr via options.

This is one of the needed fixes for https://github.com/libp2p/js-libp2p-webrtc-direct/issues/94#issuecomment-756613029

Needs:
- [x] #91