### PR TITLE
Fixed wrong import name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm i @libp2p/webrtc-direct
 ## Usage
 
 ```js
-import { createLibp2pNode } from 'libp2p'
+import { createLibp2p } from 'libp2p'
 import { webRTCDirect } from '@libp2p/webrtc-direct'
 
 const node = await createLibp2p({


### PR DESCRIPTION
Changed the import name from:
```javascript
import { createLibp2pNode } from libp2p
```
to
```javascript
import { createLibp2p } from libp2p
```